### PR TITLE
[zbar] Apply patch to allow cross building on Mac

### DIFF
--- a/recipes/zbar/all/conandata.yml
+++ b/recipes/zbar/all/conandata.yml
@@ -5,3 +5,8 @@ sources:
   "0.10":
     url: "https://sourceforge.net/projects/zbar/files/zbar/0.10/zbar-0.10.tar.gz"
     sha256: "575fa82de699faa7bda2d2ebbe3e1af0a4152ec4d3ad72c0ab6712d7cc9b5dd2"
+patches:
+  "0.10":
+    - patch_file: "patches/0001-support-aarch.patch"
+      patch_description: "Add support for Mac M1"
+      patch_type: "portability"

--- a/recipes/zbar/all/conanfile.py
+++ b/recipes/zbar/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
 from conan.tools.build import cross_building
-from conan.tools.files import get, copy, rmdir, rm, collect_libs
+from conan.tools.files import get, copy, rmdir, rm, collect_libs, export_conandata_patches, apply_conandata_patches
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.env import Environment
 from conan.tools.scm import Version
@@ -50,6 +50,9 @@ class ZbarConan(ConanFile):
         "with_jpeg": False,
         "enable_pthread": True,
     }
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -119,6 +122,7 @@ class ZbarConan(ConanFile):
 
 
     def build(self):
+        apply_conandata_patches(self)
         copy(self, "config.sub", src=self.source_folder, dst=os.path.join(self.source_folder, "config"))
         copy(self, "config.guess", src=self.source_folder, dst=os.path.join(self.source_folder, "config"))
 

--- a/recipes/zbar/all/patches/0001-support-aarch.patch
+++ b/recipes/zbar/all/patches/0001-support-aarch.patch
@@ -1,0 +1,12 @@
+diff --git a/config/config.sub b/config/config.sub
+index 848a7a5..8fecc04 100755
+--- a/config/config.sub
++++ b/config/config.sub
+@@ -322,6 +322,7 @@ case $basic_machine in
+ 	| alpha64-* | alpha64ev[4-8]-* | alpha64ev56-* | alpha64ev6[78]-* \
+ 	| alphapca5[67]-* | alpha64pca5[67]-* | arc-* \
+ 	| arm-*  | armbe-* | armle-* | armeb-* | armv*-* \
++	| aarch64-* | aarch64_be-* \
+ 	| avr-* | avr32-* \
+ 	| bfin-* | bs2000-* \
+ 	| c[123]* | c30-* | [cjt]90-* | c4x-* | c54x-* | c55x-* | c6x-* \


### PR DESCRIPTION
The version 0.10 uses a config.sub to list supported architectures and aarch is not listed there. This PR adds a patch add such support to Mac M1


Related issue: https://github.com/mchehab/zbar/issues/129

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
